### PR TITLE
fix: productionモードの時^data-testタグを消す

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  compiler: {
+    reactRemoveProperties: process.env.NODE_ENV === 'production'
+  }
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   compiler: {
-    reactRemoveProperties: process.env.NODE_ENV === 'production'
+    reactRemoveProperties: process.env.NODE_ENV === 'production',
   },
   experimental: {
     esmExternals: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "next.config.js"]
 }


### PR DESCRIPTION
Closes #12 
Testing Libraryは、HTML属性に`data-testid`タグを追加することで、テストしたいDOMの検索を`getByTestId`で探すことが可能です。
https://testing-library.com/docs/queries/bytestid/

このプルリクのオプションを入れることで、develop時は`data-testid`を残し、production時は`data-testid`タグを削除します。
https://nextjs.org/docs/advanced-features/compiler#remove-react-properties